### PR TITLE
Update CSV according to redhat-developer/service-binding-operator#132

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ push-operator-image-stable: build-operator-image-stable
 	docker push $(OPERATOR_IMAGE):$(OPERATOR_STABLE_VERSION)
 
 .PHONY: deploy-operator-package
-deploy-operator-package: push-operator-image get-tag
+deploy-operator-package: get-tag
 	$(eval OPERATOR_MANIFESTS := tmp/manifests)
 	$(eval CREATION_TIMESTAMP := $(shell date --date="@$(TAG)" '+%Y-%m-%d %H:%M:%S'))
 	$(eval ICON_BASE64_DATA := $(shell cat ./icon/pgo.png | base64))

--- a/manifests/nightly/postgresql-operator.v0.0.6.clusterserviceversion.yaml
+++ b/manifests/nightly/postgresql-operator.v0.0.6.clusterserviceversion.yaml
@@ -147,37 +147,37 @@ spec:
             displayName: DB name
             path: dbName
             x-descriptors:
-              - urn:alm:descriptor:servicebindingrequest:env:attribute
+              - binding:env:attribute
         statusDescriptors:
           - description: Name of the Secret to hold the DB user and password
             displayName: DB Password Credentials
             path: dbCredentials
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes:Secret
-              - urn:alm:descriptor:servicebindingrequest:env:object:secret:user
-              - urn:alm:descriptor:servicebindingrequest:env:object:secret:password
+              - binding:env:object:secret:user
+              - binding:env:object:secret:password
           - description: Database connection IP address
             displayName: DB IP address
             path: dbConnectionIP
             x-descriptors:
-              - urn:alm:descriptor:servicebindingrequest:env:attribute
+              - binding:env:attribute
           - description: Database connection port
             displayName: DB port
             path: dbConnectionPort
             x-descriptors:
-              - urn:alm:descriptor:servicebindingrequest:env:attribute
+              - binding:env:attribute
           - description: Database name
             displayName: DB name
             path: dbName
             x-descriptors:
-              - urn:alm:descriptor:servicebindingrequest:env:attribute
+              - binding:env:attribute
           - description: Name of the ConfigMap to hold the DB config
             displayName: DB Config Map
             path: dbConfigMap
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes:ConfigMap
-              - urn:alm:descriptor:servicebindingrequest:env:object:configmap:db.host
-              - urn:alm:descriptor:servicebindingrequest:env:object:configmap:db.port
-              - urn:alm:descriptor:servicebindingrequest:env:object:configmap:db.name
-              - urn:alm:descriptor:servicebindingrequest:env:object:configmap:db.user
-              - urn:alm:descriptor:servicebindingrequest:env:object:configmap:db.password
+              - binding:env:object:configmap:db.host
+              - binding:env:object:configmap:db.port
+              - binding:env:object:configmap:db.name
+              - binding:env:object:configmap:db.user
+              - binding:env:object:configmap:db.password


### PR DESCRIPTION
This PR changes Service Binding Operator's annotations in CSV from:

`urn:alm:descriptor:servicebindingrequest:*`

to:

 `binding:*`

according to redhat-developer/service-binding-operator#132